### PR TITLE
Allow build of sea ice column package in MPAS-Ocean

### DIFF
--- a/components/mpas-ocean/src/Makefile
+++ b/components/mpas-ocean/src/Makefile
@@ -9,6 +9,9 @@ FRAMEWORK_DIR = ../../../mpas-framework/src
 OCEAN_SHARED_INCLUDES = -I$(FRAMEWORK_DIR)/framework -I$(FRAMEWORK_DIR)/external/esmf_time_f90 -I$(FRAMEWORK_DIR)/operators
 OCEAN_SHARED_INCLUDES += -I$(PWD)/shared -I$(PWD)/analysis_members -I$(PWD)/mode_forward -I$(PWD)/mode_analysis
 OCEAN_SHARED_INCLUDES += -I$(PWD)/BGC -I$(PWD)/MARBL/include -I$(PWD)/cvmix/src/shared -I$(PWD)/gotm/build -I$(PWD)/gotm/build/modules -I$(PWD)/SHTNS -I$(PWD)/ppr/src
+ifeq "$(SEAICE_COLUMN)" "true"
+	OCEAN_SHARED_INCLUDES += -I$(PWD)/seaice_driver -I$(PWD)/seaice_column
+endif
 ifneq "$(EXCLUDE_INIT_MODE)" "true"
 	OCEAN_SHARED_INCLUDES += -I$(PWD)/mode_init
 endif
@@ -22,8 +25,12 @@ ifneq "$(EXCLUDE_INIT_MODE)" "true"
 	OCEAN_SHARED_INCLUDES += -I$(PWD)/mode_init
 endif
 
-all: shared libcvmix analysis_members libBGC libMARBL libgotm libfftw libshtns libppr
-	(cd mode_forward; $(MAKE) FCINCLUDES="$(FCINCLUDES) $(OCEAN_SHARED_INCLUDES)" all )
+ifeq "$(SEAICE_COLUMN)" "true"
+	override CPPFLAGS += -DSEAICE_COLUMN
+endif
+
+all: shared libcvmix analysis_members libBGC libMARBL libgotm libfftw libshtns libppr libseaice
+	(cd mode_forward; $(MAKE) CPPFLAGS="$(CPPFLAGS)" FCINCLUDES="$(FCINCLUDES) $(OCEAN_SHARED_INCLUDES)" all )
 	(cd mode_analysis; $(MAKE) FCINCLUDES="$(FCINCLUDES) $(OCEAN_SHARED_INCLUDES)" all )
 ifneq "$(EXCLUDE_INIT_MODE)" "true"
 	(cd mode_init; $(MAKE) FCINCLUDES="$(FCINCLUDES) $(OCEAN_SHARED_INCLUDES)" all )
@@ -32,7 +39,7 @@ endif
 	if [ -e libdycore.a ]; then \
 		($(RM) libdycore.a) \
 	fi
-	ar -ru libdycore.a `find . -type f -name "*.o"`
+	ar -ru libdycore.a `find -L . -type f -name "*.o"`
 
 core_reg:
 	$(CPP) $(CPPFLAGS) $(CPPLOCALFLAGS) $(CPPINCLUDES) Registry.xml > Registry_processed.xml
@@ -138,7 +145,13 @@ libppr:
 		(pwd ; echo "Missing core_ocean/ppr/.git, did you forget to 'git submodule update --init --recursive' ?"; exit 1) \
 	fi
 
-shared: libcvmix libBGC libMARBL libgotm libshtns libfftw libppr
+libseaice:
+ifeq "$(SEAICE_COLUMN)" "true"
+	(cd seaice_column; $(MAKE))
+	(cd seaice_driver; $(MAKE))
+endif
+
+shared: libcvmix libBGC libMARBL libgotm libshtns libfftw libppr libseaice
 	(cd shared; $(MAKE) FCINCLUDES="$(FCINCLUDES) $(OCEAN_SHARED_INCLUDES)")
 
 analysis_members: libcvmix shared libgotm
@@ -166,6 +179,10 @@ clean:
 	if [ -e FFTW/.git ]; then \
 		(cd FFTW; make clean; rm -f $(SHTNS_DIR)/lib/libfftw3*) \
 	fi
+ifeq "$(SEAICE_COLUMN)" "true"
+	(cd seaice_column; $(MAKE) clean)
+	(cd seaice_driver; $(MAKE) clean)
+endif
 	(cd mode_forward; $(MAKE) clean)
 	(cd mode_analysis; $(MAKE) clean)
 	(cd mode_init; $(MAKE) clean)

--- a/components/mpas-ocean/src/mode_forward/mpas_ocn_forward_mode.F
+++ b/components/mpas-ocean/src/mode_forward/mpas_ocn_forward_mode.F
@@ -95,6 +95,10 @@ module ocn_forward_mode
    use ocn_constants
    use ocn_config
 
+#ifdef SEAICE_COLUMN
+   use ocn_seaice_column
+#endif
+
    implicit none
    private
 
@@ -506,6 +510,11 @@ module ocn_forward_mode
               MPAS_LOG_ERR, masterOnly=.true., flushNow=.true.)
          return
       endif
+
+#ifdef SEAICE_COLUMN
+      ! Initialize sea ice column package
+      call ocn_init_seaice(domain)
+#endif
 
    !--------------------------------------------------------------------
 

--- a/components/mpas-ocean/src/seaice_column
+++ b/components/mpas-ocean/src/seaice_column
@@ -1,0 +1,1 @@
+../../mpas-seaice/src/column/

--- a/components/mpas-ocean/src/seaice_driver/Makefile
+++ b/components/mpas-ocean/src/seaice_driver/Makefile
@@ -1,0 +1,32 @@
+.SUFFIXES: .F .o
+
+OBJS = 	mpas_seaice_column.o \
+	mpas_seaice_error.o \
+	mpas_seaice_constants.o \
+	mpas_ocn_seaice_column.o
+
+all: $(OBJS)
+	ar -ru libseaice_driver.a $(OBJS)
+
+mpas_seaice_error.o:
+
+mpas_seaice_constants.o:
+
+mpas_seaice_column.o: mpas_seaice_constants.o mpas_seaice_error.o
+
+mpas_ocn_seaice_column.o: mpas_seaice_column.o
+
+clean:
+	$(RM) *.o *.i *.mod *.f90
+
+FW = ../../../mpas-framework/src
+
+.F.o:
+	$(RM) $@ $*.mod
+ifeq "$(GEN_F90)" "true"
+	$(CPP) $(CPPFLAGS) $(CPPINCLUDES) $< > $*.f90
+
+	$(FC) $(FFLAGS) -c $*.f90 $(FCINCLUDES) -I$(FW)/framework -I$(FW)/operators -I$(FW)/external/esmf_time_f90 -I../seaice_column
+else
+	$(FC) $(CPPFLAGS) $(FFLAGS) -c $*.F $(CPPINCLUDES) $(FCINCLUDES) -I$(FW)/framework -I$(FW)/operators -I$(FW)/external/esmf_time_f90 -I../seaice_column
+endif

--- a/components/mpas-ocean/src/seaice_driver/mpas_ocn_seaice_column.F
+++ b/components/mpas-ocean/src/seaice_driver/mpas_ocn_seaice_column.F
@@ -1,0 +1,62 @@
+! Copyright (c) 2013,  Los Alamos National Security, LLC (LANS)
+! and the University Corporation for Atmospheric Research (UCAR).
+!
+! Unless noted otherwise source code is licensed under the BSD license.
+! Additional copyright and license information can be found in the LICENSE file
+! distributed with this code, or at http://mpas-dev.github.io/license.html
+!
+!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
+!
+!  ocn_seaice_driver
+!
+!> \brief   Driver for sea ice column package
+!> \author  Adrian K. Turner
+!> \date    30th November 2022
+!> \details This module controls the use the sea ice column package
+!>          directly from MPAS-Ocean
+!
+!-----------------------------------------------------------------------
+
+module ocn_seaice_column
+
+  use mpas_derived_types
+  use mpas_log
+
+  implicit none
+  private
+
+  public :: &
+       ocn_init_seaice
+
+!***********************************************************************
+
+contains
+
+!***********************************************************************
+!
+!  function ocn_init_seaice
+!
+!> \brief   Initialize the sea ice column package
+!> \author  Adrian K. Turner
+!> \date    30th November 2022
+!> \details Perform operations that initialize the sea ice column
+!>          package when run directly from MPAS-Ocean
+!
+!-----------------------------------------------------------------------
+
+  subroutine ocn_init_seaice(domain)!{{{
+
+    use seaice_column, only: &
+         seaice_init_column_physics_package_parameters
+
+    type (domain_type), intent(inout) :: domain
+
+    call mpas_log_write("RUNNING SEA ICE!")
+
+    call seaice_init_column_physics_package_parameters(domain)
+
+  end subroutine ocn_init_seaice!}}}
+
+end module ocn_seaice_column
+
+! vim: foldmethod=marker

--- a/components/mpas-ocean/src/seaice_driver/mpas_seaice_column.F
+++ b/components/mpas-ocean/src/seaice_driver/mpas_seaice_column.F
@@ -1,0 +1,1 @@
+../../../mpas-seaice/src/shared/mpas_seaice_column.F

--- a/components/mpas-ocean/src/seaice_driver/mpas_seaice_constants.F
+++ b/components/mpas-ocean/src/seaice_driver/mpas_seaice_constants.F
@@ -1,0 +1,1 @@
+../../../mpas-seaice/src/shared/mpas_seaice_constants.F

--- a/components/mpas-ocean/src/seaice_driver/mpas_seaice_error.F
+++ b/components/mpas-ocean/src/seaice_driver/mpas_seaice_error.F
@@ -1,0 +1,1 @@
+../../../mpas-seaice/src/shared/mpas_seaice_error.F

--- a/components/mpas-seaice/src/shared/Makefile
+++ b/components/mpas-seaice/src/shared/Makefile
@@ -34,7 +34,7 @@ mpas_seaice_error.o:
 
 mpas_seaice_mesh_pool.o:
 
-mpas_seaice_column.o: mpas_seaice_error.o
+mpas_seaice_column.o: mpas_seaice_constants.o mpas_seaice_error.o
 
 mpas_seaice_diagnostics.o: mpas_seaice_constants.o
 

--- a/components/mpas-seaice/src/shared/mpas_seaice_column.F
+++ b/components/mpas-seaice/src/shared/mpas_seaice_column.F
@@ -1287,9 +1287,6 @@ contains
     use seaice_constants, only: &
          seaicePuny
 
-    use seaice_mesh, only: &
-         seaice_interpolate_vertex_to_cell
-
     type(domain_type), intent(inout) :: domain
 
     type(MPAS_clock_type), intent(in) :: clock
@@ -1314,8 +1311,7 @@ contains
          ponds, &
          aerosols, &
          diagnostics, &
-         snow, &
-         boundary
+         snow
 
     ! configs
     real(kind=RKIND), pointer :: &
@@ -1324,8 +1320,7 @@ contains
     logical, pointer :: &
          config_use_aerosols, &
          config_use_prescribed_ice, &
-         config_use_snow_liquid_ponds, &
-         config_use_high_frequency_coupling
+         config_use_snow_liquid_ponds
 
     ! dimensions
     integer, pointer :: &
@@ -1342,8 +1337,6 @@ contains
          iceAreaCell, &
          iceVolumeCell, &
          snowVolumeCell, &
-         uVelocity, &
-         vvelocity, &
          uVelocityCell, &
          vvelocityCell, &
          uAirVelocity, &
@@ -1518,13 +1511,11 @@ contains
        call MPAS_pool_get_subpool(block % structs, "aerosols", aerosols)
        call MPAS_pool_get_subpool(block % structs, "diagnostics", diagnostics)
        call MPAS_pool_get_subpool(block % structs, "snow", snow)
-       call MPAS_pool_get_subpool(block % structs, "boundary", boundary)
 
        call MPAS_pool_get_config(block % configs, "config_dt", config_dt)
        call MPAS_pool_get_config(block % configs, "config_use_aerosols", config_use_aerosols)
        call MPAS_pool_get_config(block % configs, "config_use_prescribed_ice", config_use_prescribed_ice)
        call MPAS_pool_get_config(block % configs, "config_use_snow_liquid_ponds", config_use_snow_liquid_ponds)
-       call MPAS_pool_get_config(block % configs, "config_use_high_frequency_coupling", config_use_high_frequency_coupling)
 
        call MPAS_pool_get_dimension(mesh, "nCellsSolve", nCellsSolve)
        call MPAS_pool_get_dimension(mesh, "nCategories", nCategories)
@@ -1567,8 +1558,6 @@ contains
        call MPAS_pool_get_array(tracers, "snowLiquidMass", snowLiquidMass, 1)
        call MPAS_pool_get_array(tracers, "snowGrainRadius", snowGrainRadius, 1)
 
-       call MPAS_pool_get_array(velocity_solver, "uVelocity", uVelocity)
-       call MPAS_pool_get_array(velocity_solver, "vVelocity", vVelocity)
        call MPAS_pool_get_array(velocity_solver, "uVelocityCell", uVelocityCell)
        call MPAS_pool_get_array(velocity_solver, "vVelocityCell", vVelocityCell)
        call MPAS_pool_get_array(velocity_solver, "airStressCellU", airStressCellU)
@@ -1676,12 +1665,6 @@ contains
        call MPAS_pool_get_array(snow, "snowLossToLeads", snowLossToLeads)
        call MPAS_pool_get_array(snow, "snowMeltMassCell", snowMeltMassCell)
        call MPAS_pool_get_array(snow, "snowMeltMassCategory", snowMeltMassCategory)
-
-       ! high frequency coupling needs to cell center velocity
-       if (config_use_high_frequency_coupling) then
-          call seaice_interpolate_vertex_to_cell(mesh, boundary, uVelocityCell, uVelocity)
-          call seaice_interpolate_vertex_to_cell(mesh, boundary, vVelocityCell, vVelocity)
-       endif
 
        ! aerosols
        if (config_use_aerosols) then

--- a/components/mpas-seaice/src/shared/mpas_seaice_velocity_solver.F
+++ b/components/mpas-seaice/src/shared/mpas_seaice_velocity_solver.F
@@ -3380,6 +3380,11 @@ contains
     call ocean_stress_final(domain)
     call mpas_timer_stop("ocn stress final")
 
+    ! calculate cell velocity for high frequency coupling
+    call mpas_timer_start("cell velocity")
+    call cell_velocity(domain)
+    call mpas_timer_stop("cell velocity")
+
   end subroutine velocity_solver_post_subcycle
 
 !|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
@@ -3850,6 +3855,71 @@ contains
 
   end subroutine ocean_stress_final
 
-  !-----------------------------------------------------------------------
+!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
+!
+!  cell_velocity
+!
+!> \brief
+!> \author Adrian K. Turner, LANL
+!> \date 30th November 2022
+!> \details
+!>
+!
+!-----------------------------------------------------------------------
+
+  subroutine cell_velocity(domain)
+
+    use seaice_mesh, only: &
+         seaice_interpolate_vertex_to_cell
+
+    type(domain_type), intent(inout) :: &
+         domain
+
+    type(block_type), pointer :: &
+         blockPtr
+
+    type(MPAS_pool_type), pointer :: &
+         meshPool, &
+         boundaryPool, &
+         velocitySolverPool
+
+    logical, pointer :: &
+         config_use_high_frequency_coupling
+
+    real(kind=RKIND), dimension(:), pointer :: &
+         uVelocity, &
+         vvelocity, &
+         uVelocityCell, &
+         vvelocityCell
+
+    call MPAS_pool_get_config(domain % configs, "config_use_high_frequency_coupling", &
+                                                 config_use_high_frequency_coupling)
+
+    ! high frequency coupling needs to cell center velocity
+    if (config_use_high_frequency_coupling) then
+
+       blockPtr => domain % blocklist
+       do while (associated(blockPtr))
+
+          call MPAS_pool_get_subpool(blockPtr % structs, "mesh", meshPool)
+          call MPAS_pool_get_subpool(blockPtr % structs, "boundary", boundaryPool)
+          call MPAS_pool_get_subpool(blockPtr % structs, "velocity_solver", velocitySolverPool)
+
+          call MPAS_pool_get_array(velocitySolverPool, "uVelocity", uVelocity)
+          call MPAS_pool_get_array(velocitySolverPool, "vVelocity", vVelocity)
+          call MPAS_pool_get_array(velocitySolverPool, "uVelocityCell", uVelocityCell)
+          call MPAS_pool_get_array(velocitySolverPool, "vVelocityCell", vVelocityCell)
+
+          call seaice_interpolate_vertex_to_cell(meshPool, boundaryPool, uVelocityCell, uVelocity)
+          call seaice_interpolate_vertex_to_cell(meshPool, boundaryPool, vVelocityCell, vVelocity)
+
+          blockPtr => blockPtr % next
+       end do
+
+    endif ! config_use_high_frequency_coupling
+
+  end subroutine cell_velocity
+
+!-----------------------------------------------------------------------
 
 end module seaice_velocity_solver


### PR DESCRIPTION
This PR allows the MPAS-Seaice column package to be built as part of the MPAS-Ocean model. The intention is to allow a thermodynamic sea ice layer as an upper boundary condition in MPAS-LES simulations. The alternative would be to use the E3SM coupler to MPAS-Seaice directly, but idealized test cases are not currently supported in E3SM.

- The MPAS-Seaice column package directory is now a sym link from the ocean src directory - called seaice_column
- There is a new directory in the ocean src directory, called seaice_driver, that contains the needed MPAS_Seaice shared directory files and a new ocean file (mpas_ocn_seaice_column.F) that is the interface to the rest of the ocean model
-  The sea ice files are only built when the SEAICE_COLUMN=true flag is used with the main make command.
-  Only a call to a sea ice initialization subroutine has been implemented so far
-  Some changes were also made to some MPAS-Seaice files to remove some dependencies in the seaice column driver subroutines.