### PR TITLE
Reduced sea ice domain in E3SM

### DIFF
--- a/components/mpas-seaice/driver/ice_comp_mct.F
+++ b/components/mpas-seaice/driver/ice_comp_mct.F
@@ -1449,6 +1449,15 @@ contains
       n = n + nCellsSolve
       block_ptr => block_ptr % next
     end do
+    block_ptr => domain % blocklist
+    do while(associated(block_ptr))
+      call mpas_pool_get_subpool(block_ptr % structs, 'mesh', meshPool)
+
+      call mpas_pool_get_dimension(meshPool, 'nCellsCulled', nCellsSolve)
+
+      n = n + nCellsSolve
+      block_ptr => block_ptr % next
+    end do
 
     ! Determine total number of cells across all processors
     lsize = n
@@ -1463,7 +1472,21 @@ contains
 
       call mpas_pool_get_dimension(meshPool, 'nCellsSolve', nCellsSolve)
 
-      call mpas_pool_get_array(meshPool, 'indexToCellID', indexToCellID)
+      call mpas_pool_get_array(meshPool, 'indexToOceanCellID', indexToCellID)
+
+      do i = 1, nCellsSolve
+        n = n + 1
+        gindex(n) = indexToCellID(i)
+      end do
+      block_ptr => block_ptr % next
+    end do
+    block_ptr => domain % blocklist
+    do while(associated(block_ptr))
+      call mpas_pool_get_subpool(block_ptr % structs, 'mesh', meshPool)
+
+      call mpas_pool_get_dimension(meshPool, 'nCellsCulled', nCellsSolve)
+
+      call mpas_pool_get_array(meshPool, 'indexToCulledCellID', indexToCellID)
 
       do i = 1, nCellsSolve
         n = n + 1
@@ -1586,6 +1609,22 @@ contains
 
        block_ptr => block_ptr % next
     end do
+    block_ptr => domain % blocklist
+    do while(associated(block_ptr))
+       call mpas_pool_get_subpool(block_ptr % structs, 'mesh', meshPool)
+
+       call mpas_pool_get_dimension(meshPool, 'nCellsCulled', nCellsSolve)
+
+       call mpas_pool_get_array(meshPool, 'lonCellCulled', lonCell)
+
+       do i = 1, nCellsSolve
+          n = n + 1
+          data(n) = lonCell(i) * r2d
+       end do
+
+       block_ptr => block_ptr % next
+    end do
+
     call mct_gGrid_importRattr(dom_i,"lon",data,lsize)
 
     n = 0
@@ -1596,6 +1635,20 @@ contains
        call mpas_pool_get_dimension(meshPool, 'nCellsSolve', nCellsSolve)
 
        call mpas_pool_get_array(meshPool, 'latCell', latCell)
+
+       do i = 1, nCellsSolve
+          n = n + 1
+          data(n) = latCell(i) * r2d
+       end do
+       block_ptr => block_ptr % next
+    end do
+    block_ptr => domain % blocklist
+    do while(associated(block_ptr))
+       call mpas_pool_get_subpool(block_ptr % structs, 'mesh', meshPool)
+
+       call mpas_pool_get_dimension(meshPool, 'nCellsCulled', nCellsSolve)
+
+       call mpas_pool_get_array(meshPool, 'latCellCulled', latCell)
 
        do i = 1, nCellsSolve
           n = n + 1
@@ -1621,9 +1674,25 @@ contains
        end do
        block_ptr => block_ptr % next
     end do
+    block_ptr => domain % blocklist
+    do while(associated(block_ptr))
+       call mpas_pool_get_subpool(block_ptr % structs, 'mesh', meshPool)
+
+       call mpas_pool_get_dimension(meshPool, 'nCellsCulled', nCellsSolve)
+
+       call mpas_pool_get_array(meshPool, 'areaCellCulled', areaCell)
+
+       call mpas_pool_get_config(meshPool, 'sphere_radius', sphere_radius)
+       do i = 1, nCellsSolve
+          n = n + 1
+          data(n) = areaCell(i) / (sphere_radius * sphere_radius)
+       end do
+       block_ptr => block_ptr % next
+    end do
     call mct_gGrid_importRattr(dom_i,"area",data,lsize)
 
     ! Build mask and frac based on landIceMask
+    n = 0
     block_ptr => domain % blocklist
     do while ( associated(block_ptr) )
        call mpas_pool_get_subpool(block_ptr % structs, 'mesh', meshPool)
@@ -1635,17 +1704,31 @@ contains
 
        if ( associated(landIceMask) ) then
           do i = 1, nCellsSolve
+             n = n + 1
              if ( landIceMask(i) == 1 ) then
-                data(i) = 0.0_RKIND
+                data(n) = 0.0_RKIND
              else
-                data(i) = 1.0_RKIND
+                data(n) = 1.0_RKIND
              end if
           end do
        else
           do i = 1, nCellsSolve
-             data(i) = 1.0_RKIND
+             n = n + 1
+             data(n) = 1.0_RKIND
           end do
        end if
+
+       block_ptr => block_ptr % next
+    end do
+    block_ptr => domain % blocklist
+    do while ( associated(block_ptr) )
+       call mpas_pool_get_subpool(block_ptr % structs, 'mesh', meshPool)
+
+       call mpas_pool_get_dimension(meshPool, 'nCellsCulled', nCellsSolve)
+       do i = 1, nCellsSolve
+          n = n + 1
+          data(n) = 1.0_RKIND
+       end do
 
        block_ptr => block_ptr % next
     end do

--- a/components/mpas-seaice/src/Registry.xml
+++ b/components/mpas-seaice/src/Registry.xml
@@ -401,6 +401,10 @@
 			description="Determines if mpi barriers are used and timed before halo exchanges."
 			possible_values=".true. or .false."
 		/>
+		<nml_option name="config_use_culled_mesh" type="logical" default_value="false" units="unitless"
+			description="Allow sea ice to occupy subset of ocean mesh in E3SM"
+			possible_values=".true. or .false."
+		/>
 	</nml_record>
 	<nml_record name="restart" in_defaults="true">
 		<nml_option name="config_do_restart" type="logical" default_value="false" units="unitless"
@@ -2351,34 +2355,6 @@
 		     dimensions="nCells"
 		     description="List of global cell IDs."
 		/>
-		<var name="indexToOceanCellID"
-		     type="integer"
-		     dimensions="nCells"
-		     description="List of ocean mesh global cell IDs."
-		/>
-		<var name="indexToCulledCellID"
-		     type="integer"
-		     dimensions="nCellsCulled"
-		     description="List of culled mesh globals cell IDs."
-		/>
-		<var name="latCellCulled"
-		     type="real"
-		     dimensions="nCellsCulled"
-		     units="radians"
-		     description="Latitude location of culled cell centers in radians."
-		/>
-		<var name="lonCellCulled"
-		     type="real"
-		     dimensions="nCellsCulled"
-		     units="radians"
-		     description="Longitude location of culled cell centers in radians."
-		/>
-		<var name="areaCellCulled"
-		     type="real"
-		     dimensions="nCellsCulled"
-		     units="m2"
-		     description="Area of each cell in the primary grid."
-		/>
 		<var name="latEdge"
 		     type="real"
 		     dimensions="nEdges"
@@ -2560,7 +2536,41 @@
 		/>
 	</var_struct>
 
+	<var_struct name="mesh_culled" time_levs="1" packages="pkgCulledMesh">
+		<var name="indexToOceanCellID"
+		     type="integer"
+		     dimensions="nCells"
+		     description="List of ocean mesh global cell IDs."
+		/>
+		<var name="indexToCulledCellID"
+		     type="integer"
+		     dimensions="nCellsCulled"
+		     description="List of culled mesh globals cell IDs."
+		/>
+		<var name="latCellCulled"
+		     type="real"
+		     dimensions="nCellsCulled"
+		     units="radians"
+		     description="Latitude location of culled cell centers in radians."
+		/>
+		<var name="lonCellCulled"
+		     type="real"
+		     dimensions="nCellsCulled"
+		     units="radians"
+		     description="Longitude location of culled cell centers in radians."
+		/>
+		<var name="areaCellCulled"
+		     type="real"
+		     dimensions="nCellsCulled"
+		     units="m2"
+		     description="Area of each cell in the primary grid."
+		/>
+	</var_struct>
+
 	<packages>
+
+		<!-- mesh packages -->
+		<package name="pkgCulledMesh" description=""/>
 
 		<!-- dynamics packages -->
 		<package name="pkgWeak" description=""/>

--- a/components/mpas-seaice/src/Registry.xml
+++ b/components/mpas-seaice/src/Registry.xml
@@ -5,6 +5,9 @@
 		<dim name="nCells"
 			description="The number of polygons in the primary grid."
 		/>
+		<dim name="nCellsCulled" decomposition="uniform"
+			description="The number of culled polygons in the primary grid."
+		/>
 		<dim name="nEdges"
 			description="The number of edge midpoints in either the primary or dual grid."
 		/>
@@ -1875,6 +1878,11 @@
 			<var name="yCell"/>
 			<var name="zCell"/>
 			<var name="indexToCellID"/>
+			<var name="indexToOceanCellID"/>
+			<var name="indexToCulledCellID"/>
+			<var name="latCellCulled"/>
+			<var name="lonCellCulled"/>
+			<var name="areaCellCulled"/>
 			<var name="latEdge"/>
 			<var name="lonEdge"/>
 			<var name="xEdge"/>
@@ -2342,6 +2350,34 @@
 		     type="integer"
 		     dimensions="nCells"
 		     description="List of global cell IDs."
+		/>
+		<var name="indexToOceanCellID"
+		     type="integer"
+		     dimensions="nCells"
+		     description="List of ocean mesh global cell IDs."
+		/>
+		<var name="indexToCulledCellID"
+		     type="integer"
+		     dimensions="nCellsCulled"
+		     description="List of culled mesh globals cell IDs."
+		/>
+		<var name="latCellCulled"
+		     type="real"
+		     dimensions="nCellsCulled"
+		     units="radians"
+		     description="Latitude location of culled cell centers in radians."
+		/>
+		<var name="lonCellCulled"
+		     type="real"
+		     dimensions="nCellsCulled"
+		     units="radians"
+		     description="Longitude location of culled cell centers in radians."
+		/>
+		<var name="areaCellCulled"
+		     type="real"
+		     dimensions="nCellsCulled"
+		     units="m2"
+		     description="Area of each cell in the primary grid."
 		/>
 		<var name="latEdge"
 		     type="real"

--- a/components/mpas-seaice/src/model_forward/mpas_seaice_core_interface.F
+++ b/components/mpas-seaice/src/model_forward/mpas_seaice_core_interface.F
@@ -95,6 +95,9 @@ module seaice_core_interface
 
       ierr = 0
 
+      ! mesh
+      call setup_packages_mesh(configPool, packagePool, ierr)
+
       ! dynamics
       call setup_packages_dynamics(configPool, packagePool, ierr)
 
@@ -111,6 +114,42 @@ module seaice_core_interface
       call setup_packages_other(configPool, packagePool, ierr)
 
    end function seaice_setup_packages!}}}
+
+   !***********************************************************************
+   !
+   !  routine setup_packages_mesh
+   !
+   !> \brief
+   !> \author  Adrian K. Turner
+   !> \date    27th February 2023
+   !> \details Set packages for mesh related quantities
+   !>
+   !
+   !-----------------------------------------------------------------------
+
+   subroutine setup_packages_mesh(configPool, packagePool, ierr)!{{{
+
+     type (mpas_pool_type), intent(in) :: configPool
+     type (mpas_pool_type), intent(in) :: packagePool
+     integer, intent(out) :: ierr
+
+     logical, pointer :: &
+          config_use_culled_mesh
+
+     logical, pointer :: &
+          pkgCulledMeshActive
+
+     call MPAS_pool_get_config(configPool, "config_use_culled_mesh", config_use_culled_mesh)
+
+     call MPAS_pool_get_package(packagePool, "pkgCulledMeshActive", pkgCulledMeshActive)
+
+     if (config_use_culled_mesh) then
+
+        pkgCulledMeshActive = .true.
+
+     endif
+
+   end subroutine setup_packages_mesh!}}}
 
    !***********************************************************************
    !


### PR DESCRIPTION
This modification allows MPAS-Seaice is use a reduced mesh with unneeded equatorial cells removed. The reduced MPAS-Seaice mesh contains information about the full ocean mesh and uses this to setup the coupling with the E3SM coupler. While the coupler couples the full domain, only the first section of cells is used by the sea ice model on each domain. This reduces unnecessary work in equatorial cells and reduces the size of output files by a considerable margin.