### PR TITLE
Change earth radius default to match CIME constant.

### DIFF
--- a/components/mpas-seaice/bld/namelist_files/namelist_defaults_mpassi.xml
+++ b/components/mpas-seaice/bld/namelist_files/namelist_defaults_mpassi.xml
@@ -72,7 +72,7 @@
 <config_nSnowLayers>5</config_nSnowLayers>
 
 <!-- initialize -->
-<config_earth_radius>6371229.0</config_earth_radius>
+<config_earth_radius>6371220.0</config_earth_radius>
 <config_initial_condition_type>'cice_default'</config_initial_condition_type>
 <config_initial_ice_area>1.0</config_initial_ice_area>
 <config_initial_ice_volume>1.0</config_initial_ice_volume>

--- a/components/mpas-seaice/src/Registry.xml
+++ b/components/mpas-seaice/src/Registry.xml
@@ -452,7 +452,7 @@
 		/>
 	</nml_record>
 	<nml_record name="initialize" in_defaults="true">
-		<nml_option name="config_earth_radius" type="real" default_value="6371229.0" units="m"
+		<nml_option name="config_earth_radius" type="real" default_value="6371220.0" units="m"
 			description="Earth radius in m"
 			possible_values="Any positive real number."
 		/>

--- a/components/mpas-seaice/src/shared/mpas_seaice_mesh.F
+++ b/components/mpas-seaice/src/shared/mpas_seaice_mesh.F
@@ -157,7 +157,13 @@ contains
     call MPAS_pool_get_config(domain % blocklist % configs, "config_do_restart", config_do_restart)
     call MPAS_pool_get_config(domain % blocklist % configs, "config_earth_radius", earthRadius)
 
-    if (abs(earthRadius - SHR_CONST_REARTH) > 0.0) call mpas_log_write('Inconsistent Earth radii')
+      if (earthRadius /= SHR_CONST_REARTH) then
+
+         call mpas_log_write(&
+                  "Inconsistent: Earth radii: SHR_CONST_REARTH: $r, config_earth_radius: $r", &
+                  messageType=MPAS_LOG_CRIT, realArgs=(/SHR_CONST_REARTH,earthRadius/))
+
+      endif
 
     if (.not. config_do_restart) then
 

--- a/components/mpas-seaice/src/shared/mpas_seaice_mesh.F
+++ b/components/mpas-seaice/src/shared/mpas_seaice_mesh.F
@@ -16,8 +16,9 @@ module seaice_mesh
   use mpas_pool_routines
   use mpas_dmpar
   use mpas_log, only: mpas_log_write
-
+#ifdef CCSMCOUPLED
   use shr_const_mod, only: SHR_CONST_REARTH
+#endif
 
   implicit none
 
@@ -156,7 +157,7 @@ contains
 
     call MPAS_pool_get_config(domain % blocklist % configs, "config_do_restart", config_do_restart)
     call MPAS_pool_get_config(domain % blocklist % configs, "config_earth_radius", earthRadius)
-
+#ifdef CCSMCOUPLED
       if (earthRadius /= SHR_CONST_REARTH) then
 
          call mpas_log_write(&
@@ -164,7 +165,7 @@ contains
                   messageType=MPAS_LOG_CRIT, realArgs=(/SHR_CONST_REARTH,earthRadius/))
 
       endif
-
+#endif
     if (.not. config_do_restart) then
 
        block => domain % blocklist

--- a/components/mpas-seaice/src/shared/mpas_seaice_mesh.F
+++ b/components/mpas-seaice/src/shared/mpas_seaice_mesh.F
@@ -17,6 +17,8 @@ module seaice_mesh
   use mpas_dmpar
   use mpas_log, only: mpas_log_write
 
+  use shr_const_mod, only: SHR_CONST_REARTH
+
   implicit none
 
   private
@@ -154,6 +156,8 @@ contains
 
     call MPAS_pool_get_config(domain % blocklist % configs, "config_do_restart", config_do_restart)
     call MPAS_pool_get_config(domain % blocklist % configs, "config_earth_radius", earthRadius)
+
+    if (abs(earthRadius - SHR_CONST_REARTH) > 0.0) call mpas_log_write('Inconsistent Earth radii')
 
     if (.not. config_do_restart) then
 

--- a/components/mpas-seaice/src/shared/mpas_seaice_mesh.F
+++ b/components/mpas-seaice/src/shared/mpas_seaice_mesh.F
@@ -292,7 +292,7 @@ contains
 
              call mpas_log_write(&
                   "rescale_mesh: inconsistent radii: sphere_radius: $r, earthRadius: $r", &
-                  messageType=MPAS_LOG_CRIT, realArgs=(/sphere_radius,earthRadius/))
+                  messageType=MPAS_LOG_WARN, realArgs=(/sphere_radius,earthRadius/))
 
           endif
 


### PR DESCRIPTION
Currently the default Earth radius in MPAS-Seaice is 6371229m, whereas the Earth radius in MPAS-Ocean uses the CIME shared constant `SHR_CONST_REARTH`=6371220m. This creates an inconsistency, where mpas-seaice mesh files inherit the `sphere_radius=6371220`, and then spun-up sea ice conditions (and restarts) have `sphere_radius=6371229`.

This changes the MPAS-Seaice default Earth radius config option to match the CIME shared constant Earth radius, and adds a check to throw a critical error if they do not match. 